### PR TITLE
Dropreviewdocumentation 20121029

### DIFF
--- a/documentation/concepts.txt
+++ b/documentation/concepts.txt
@@ -111,6 +111,6 @@ changes have been approved by reviewers, and every "issue" comment has been
 marked either as addressed or closed.
 
 Reviews can also be dropped, meaning the changes are not meant to be merged in
-their current change.  To drop a previously accepted (but not closed) review,
+their current change.  To drop a currently accepted (but not closed) review,
 you need to create an issue to "un-accept" it.  It is suitable to explain
 why the review will be dropped in that issue.


### PR DESCRIPTION
I believe a review need to have at least one issue or one non-reviewed chunk to be dropped.
