### PR TITLE
Only return True in install("blah") if it actually installed something

### DIFF
--- a/installation/prereqs.py
+++ b/installation/prereqs.py
@@ -83,8 +83,9 @@ missing software using it.
                 match = re.search(r"([^ ]+) \(.* \.\.\./([^)]+\.deb)\) \.\.\.", line)
                 if match:
                     need_blankline = True
+                    installed_anything = True
                     print "Installed: %s (%s)" % (match.group(1), match.group(2))
-            return True
+            return installed_anything
         else:
             return False
 


### PR DESCRIPTION
When I first installed Critic I told it I wanted bcrypt (which was not installed). Subsequently the installation script printed this error:

Failed to import 'bcrypt' module!  Installing it appeared to go fine, though,
so you might just need to restart this script."""

...and when I re-ran "sudo python ./install.py" indeed the issue was gone. However, fix in this pull request makes this restart unnecessary since the above error message is never printed.
