### PR TITLE
Avoid unsupported operand error

### DIFF
--- a/background/watchdog.py
+++ b/background/watchdog.py
@@ -55,7 +55,7 @@ class Watchdog(BackgroundProcess):
             if os.path.isdir(pidfile_dir):
                 pids = set(map(int, os.listdir(pidfile_dir)))
             else:
-                pids = []
+                pids = set()
 
             for pid in pids:
                 try: rss = getRSS(pid)


### PR DESCRIPTION
...
  File "background/watchdog.py", line 90, in run
    soft_restart_attempted = soft_restart_attempted & pids
TypeError: unsupported operand type(s) for &: 'set' and 'list'
