### PR TITLE
Fix for exceptions being throw due to function not being defined.

### DIFF
--- a/changeset/html.py
+++ b/changeset/html.py
@@ -305,7 +305,8 @@ def renderFile(db, target, user, review, file, first_file=False, options={}, con
     if customFileId:
         file_id = customFileId(file_id)
 
-    target.script(type="text/javascript").text("calculateTabWidth();")
+    if options.get("tabify"):
+        target.script(type="text/javascript").text("calculateTabWidth();")
 
     table = target.table(file_table_class, width='100%', cellspacing=0, cellpadding=0, id=file_id, critic_file_id=file.id, critic_parent_index=options.get("parent_index"))
 

--- a/page/showcommit.py
+++ b/page/showcommit.py
@@ -579,7 +579,8 @@ def render(db, target, user, repository, review, changesets, commits, listed_com
 
         if profiler: profiler.check("collecting relevant commits")
 
-        target.script(type="text/javascript").text("calculateTabWidth();")
+        if tabify:
+            target.script(type="text/javascript").text("calculateTabWidth();")
 
         for index, changeset in enumerate(changesets):
             parent = target.div("parent", id="p%d" % index)

--- a/page/showfile.py
+++ b/page/showfile.py
@@ -152,7 +152,9 @@ def renderShowFile(req, db, user):
         document.addInternalScript("var firstSelectedLine = %d, lastSelectedLine = %d;" % (first, last))
 
     target = body.div("main")
-    target.script(type="text/javascript").text("calculateTabWidth();")
+
+    if tabify:
+        target.script(type="text/javascript").text("calculateTabWidth();")
 
     table = target.table('file show expanded paleyellow', align='center', cellspacing=0)
 


### PR DESCRIPTION
Because resource/tabify.js, which defines calculateTabWidth(),
is conditioned on "tabify" option, these inline scripts should
be too.
