### PR TITLE
bug fix, when accessing showcommit with filter pending

### DIFF
--- a/page/showcommit.py
+++ b/page/showcommit.py
@@ -868,7 +868,7 @@ def getCommitList(db, repository, from_commit, to_commit):
                 else:
                     raise NotPossible
             else:
-                if from_commit is None and len(iter_commit.parents)==0:
+                if from_commit is None and len(iter_commit.parents) == 0:
                     return
 
                 iter_commit = gitutils.Commit.fromSHA1(db, repository, iter_commit.parents[0])


### PR DESCRIPTION
- access showcommit?review=1&filter=pending causes an error
  if the tail is the init commit in a repo, and critic think
  that it has a muti-parents to be a merge commit
