### PR TITLE
detach after writing pid file

### DIFF
--- a/background/servicemanager.py
+++ b/background/servicemanager.py
@@ -195,9 +195,8 @@ else:
     os.setuid(uid)
 
     with open(pidfile_path, "w") as pidfile:
+        daemon.detach()
         pidfile.write("%s\n" % os.getpid())
-
-    daemon.detach()
 
     was_terminated = False
 


### PR DESCRIPTION
For some reason, /var/run/critic/main was owned by root on my box.
This was easy to fix, but hard to find because I didn't see an error
in any of the /var/log/critic/main files.

This patch detaches after the pid file is written to so that the
error gets written to stderr when the you try to start the service.
