### PR TITLE
Fix install problems when user name contains utf-8

### DIFF
--- a/installation/config.py
+++ b/installation/config.py
@@ -384,7 +384,7 @@ def install(data):
                 os.chown(target_path, installation.system.uid, installation.system.gid)
 
                 with open(source_path, "r") as source:
-                    target.write((source.read().decode("utf-8") % data).encode("utf-8"))
+                    target.write(source.read() % data)
 
             path = os.path.join("configuration", entry)
             if not compile_file(path):


### PR DESCRIPTION
There is apparently no need to decode and re-encode the source files.
Doing this causes problems when the full name of the admin user
contains unicode characters (and potentially other spots in the
configuration).

I have no idea exactly why this works, when and not to use decode/encode in Python 2 is a mystery to me. I have reproduced this issue and tested the fix on one Ubuntu 13.10 desktop and one Ubuntu 13.10 server both running Python 2.7.5.

Here is an example run of the installation script that reproduces the issue (for me)
PLEASE NOTE: This will leave you with a broken install if you run it. Cleanup instructions are included below it.

```
sudo python install.py --etc-dir /etc/critic --install-dir /usr/share/critic --data-dir /var/lib/critic --cache-dir /var/cache/critic --git-dir /var/git --log-dir /var/log/critic --run-dir /var/run/critic --system-hostname critic.example.com --system-username critic --force-create-system-user --system-email critic@example.com --system-groupname critic --force-create-system-group --admin-username admin --admin-email mail@example.com --admin-fullname "Anders Höckersten" --admin-password password --auth-mode critic --session-type cookie --no-allow-anonymous-user --access-scheme http --repository-url-types git --smtp-host smtp.example.com --smtp-port 25 --smtp-no-auth --smtp-no-ssl-tls --smtp-no-starttls --skip-testmail
```

And for cleaning up after this:

```
sudo rm -rf .installed /etc/critic /usr/share/critic /var/lib/critic /var/cache/critic /var/log/critic /var/git /var/run/critic
sudo su -c "psql -c 'DROP DATABASE critic;'" - postgres
sudo su -c "psql -c 'DROP USER critic;'" - postgres
```
