### PR TITLE
Add --database-host option

### DIFF
--- a/extend.py
+++ b/extend.py
@@ -342,7 +342,8 @@ if enable and not configuration.extensions.ENABLED:
     try:
         subprocess.check_output(
             ["su", "-s", "/bin/bash",
-             "-c", "psql -q -c 'SELECT 1 FROM extensions LIMIT 1'",
+             "-c", "psql -h %s -q -c 'SELECT 1 FROM extensions LIMIT 1'" % configuration.database.PARAMETERS["host"],
+             configuration.base.
              configuration.base.SYSTEM_USER_NAME],
             stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError:

--- a/uninstall.py
+++ b/uninstall.py
@@ -129,8 +129,8 @@ This step cannot be undone! To abort the uninstall script, press CTRL-C now.
         # with sudo which makes the command run with the postgres user's homedir as cwd instead.
         # This avoids a harmless but pointless error message "could not change directory to X" when the
         # /usr/bin/psql perl script tries to chdir back to the previous cwd after doing some stuff.
-        run_command(arguments, ["sudo", "-u", "postgres", "-i", "psql", "-v", "ON_ERROR_STOP=1", "-c", "DROP DATABASE IF EXISTS %s;" % configuration.database.PARAMETERS["database"]])
-        run_command(arguments, ["sudo", "-u", "postgres", "-i", "psql", "-v", "ON_ERROR_STOP=1", "-c", "DROP ROLE IF EXISTS %s;" % configuration.database.PARAMETERS["user"]])
+        run_command(arguments, ["sudo", "-u", "postgres", "-i", "psql", "-h", configuration.database.PARAMETERS["host"], "-v", "ON_ERROR_STOP=1", "-c", "DROP DATABASE IF EXISTS %s;" % configuration.database.PARAMETERS["database"]])
+        run_command(arguments, ["sudo", "-u", "postgres", "-i", "psql", "-h", configuration.database.PARAMETERS["host"], "-v", "ON_ERROR_STOP=1", "-c", "DROP ROLE IF EXISTS %s;" % configuration.database.PARAMETERS["user"]])
 
     for user in users_to_delete:
         run_command(arguments, ["deluser", "--system", user])


### PR DESCRIPTION
Add --database-host option to define a non-local PostgreSQL database to be used by Critic host at installation time. By default --database-host is set to "localhost", which is how Critic is currently hardwired to run. This makes running Critic in a Docker container or other environment where the database host is not running on the web host feasible.
