### PR TITLE
max workers off-by-one issue

### DIFF
--- a/src/background/utils.py
+++ b/src/background/utils.py
@@ -621,7 +621,7 @@ class JSONJobServer(PeerServer):
     def __startJobs(self):
         # Repeat "start a job" while there are jobs to start and we haven't
         # reached the limit on number of concurrent jobs to run.
-        while self.__clients_with_requests and len(self.__started_requests) < self.__max_workers:
+        while self.__clients_with_requests and len(self.__started_requests) <= self.__max_workers:
             # Fetch next request from first client in list of clients with
             # pending requests.
             client = self.__clients_with_requests.pop(0)


### PR DESCRIPTION
During installation and configuration, it was observed that when CHANGESET["max_workers"] = 1, the loop will never proceed since len(self.__started_requests) will be >= 1 causing background requests to stall indefinitely.
