### PR TITLE
Make showreview comment numbering consistent

### DIFF
--- a/src/page/showreview.py
+++ b/src/page/showreview.py
@@ -958,7 +958,7 @@ def renderShowReview(req, db, user):
                     if nunread: cell.b().text("Unread")
                     else: cell.text("No replies")
                 else:
-                    if nunread: cell.b().text("%d of %d unread" % (nunread, ncomments))
+                    if nunread: cell.b().text("%d of %d unread" % (nunread, ncomments - 1))
                     else: cell.text("%d repl%s" % (ncomments - 1, "ies" if ncomments > 2 else "y"))
 
         if draft_issues:


### PR DESCRIPTION
Previously, in a thread with the original comment + 1 extra comment that had
been read by the user Critic would display the number of comments as: 1 reply.
Adding a second reply (bringing the total number of comments to 3) would be
displayed to the user as: 1 out of 3 unread.  After marking that thread as read
it will go back to display as: 2 replies.

This commit make the "total" number always refer to the number of replies
instead of alternating between the number of replies and the number of comments
in total (including the original one).