### PR TITLE
replace code.google.com links

### DIFF
--- a/installation/prereqs.py
+++ b/installation/prereqs.py
@@ -256,7 +256,7 @@ The WSGI Apache module (mod_wsgi) doesn't appear to be installed.  Make sure
 it's installed.  In Debian/Ubuntu, the package you need to install is
 'libapache2-mod-wsgi'.  The source code can be downloaded here:
 
-  http://code.google.com/p/modwsgi/wiki/DownloadTheSoftware?tm=2"""),
+  https://github.com/GrahamDumpleton/mod_wsgi"""),
 
 ]
 

--- a/src/critic.py
+++ b/src/critic.py
@@ -1127,7 +1127,7 @@ yourself.  This way you can validate the user/pass via any existing database or
 for example an LDAP server.  For more information on setting up such
 authentication in apache2, see:
 
-  <a href="%(url)s">%(url)s</a></pre>""" % { "url": "http://code.google.com/p/modwsgi/wiki/AccessControlMechanisms#Apache_Authentication_Provider" }]
+  <a href="%(url)s">%(url)s</a></pre>""" % { "url": "https://github.com/GrahamDumpleton/mod_wsgi/blob/develop/docs/user-guides/access-control-mechanisms.rst#apache-authentication-provider" }]
         except page.utils.DisplayMessage as message:
             if user is None:
                 user = dbutils.User.makeAnonymous()


### PR DESCRIPTION
code.google.com is in archive/read-only mode, let's update these links to the current targets.