### PR TITLE
Do not fail if depot_tools is already cloned

### DIFF
--- a/extend.py
+++ b/extend.py
@@ -276,9 +276,14 @@ def do_unprivileged_work():
         if arguments.with_depot_tools:
             depot_tools_url = arguments.with_depot_tools
 
-        subprocess.check_call(
-            [git, "clone", depot_tools_url],
-            cwd="installation/externals")
+        if os.path.isdir('installation/externals/depot_tools'):
+            subprocess.check_call(
+                [git, "pull"],
+                cwd="installation/externals/depot_tools")
+        else:
+            subprocess.check_call(
+                [git, "clone", depot_tools_url],
+                cwd="installation/externals")
 
         def fetch_submodule(cwd, submodule, url=None):
             subprocess.check_call(


### PR DESCRIPTION
If the build process fails and extend.py needs to be run a again it by default
tries to clone depot_tools. Let it pull instead of abort if already previously
cloned.

_As a sidenote - the reason why the build process failed for me was that I had `zlib=yes` set in my user.mk in v8-jsshell which failed with errors such as:_

> In file included from modules/ZLib.cc:23:0:
./modules/ZLib.h:56:10: error: invalid use of template-name ‘api::Class::Instance’ without an argument list

_Right now I don't recall exactly what I used that needed it. But everything built if setting zlib to no._