### PR TITLE
Implement non-anonymous LDAP access.

### DIFF
--- a/installation/templates/configuration/auth.py
+++ b/installation/templates/configuration/auth.py
@@ -107,6 +107,13 @@ DATABASES = {
         # Use TLS when connecting to LDAP server.
         "use_tls": True,
 
+        # LDAP service account.
+        #
+        # If the LDAP server does not allow anonymous access, configure
+        # an account with permission to search users.
+        "bind_dn": "",
+        "bind_password": "",
+
         # Credentials field.
         #
         # Identifier of the field whose value will be used as the credentials

--- a/src/auth/databases/ldapdb.py
+++ b/src/auth/databases/ldapdb.py
@@ -71,6 +71,8 @@ class LDAP(auth.Database):
         connection = ldap.initialize(self.configuration["url"])
         if self.configuration["use_tls"]:
             connection.start_tls_s()
+        if self.configuration["bind_dn"] and self.configuration["bind_password"]:
+            connection.simple_bind_s(self.configuration["bind_dn"], self.configuration["bind_password"])
         return connection
 
     def __isMemberOfGroup(self, connection, group, fields):


### PR DESCRIPTION
By default Active Directory LDAP servers do not allow anonymous access.

This patch implements optionally using an account for the initial bind.