### PR TITLE
sendReviewPlaceholder should not mix list/tuple returns

### DIFF
--- a/src/reviewing/mail.py
+++ b/src/reviewing/mail.py
@@ -453,7 +453,7 @@ def sendReviewPlaceholder(db, to_user, review, message_id=None):
         checkEmailEnabled(db, to_user)
         subject = generateSubjectLine(db, to_user, review, 'newishReview')
     except MailDisabled:
-        return []
+        return None, message_id
 
     line_length = to_user.getPreference(db, "email.lineLength")
     hr = "-" * line_length


### PR DESCRIPTION
Callers expect a tuple, let's not return an empty list on this corner case.