### PR TITLE
Use real manifest path for extension snapshots

### DIFF
--- a/src/extensions/extension.py
+++ b/src/extensions/extension.py
@@ -145,7 +145,7 @@ class Extension(object):
             with open(os.path.join(install_path, "MANIFEST")) as manifest_file:
                 source = manifest_file.read()
 
-            path = "<snapshot of commit %s>" % sha1[:8]
+            path = install_path
         elif version in self.__manifest:
             return self.__manifest[version]
 


### PR DESCRIPTION
When extension.getManifest() is asked for manifest of a given sha1, it
reads the manifest from the snapshot directory. It then synthesises an
invalid path, for some reason. This makes the created manifest unusable
for actually running extensions.

But the extension has a snapshot on disk from which this manifest was
read! So return the install_path of that snapshot.

This fixes ability to run non-LIVE versions of filterhook role, which
uses getManifest to avoid reading the manifest too often.

Fixes: #138